### PR TITLE
[MM-16395] Make get endpoints open to public with throttle enabled on rate and burst limits

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -35,8 +35,11 @@ functions:
             - http:
                   path: metrics
                   method: get
-                  private: true
+                  private: false
                   cors: true
+            - throttle:
+                  burstLimit: 100
+                  rateLimit: 100
 
     get_metric:
         handler: src/get_metric.default
@@ -45,8 +48,11 @@ functions:
             - http:
                   path: metric/{id}
                   method: get
-                  private: true
+                  private: false
                   cors: true
+            - throttle:
+                  burstLimit: 100
+                  rateLimit: 100
 
     post_metric:
         handler: src/post_metric.default
@@ -68,8 +74,11 @@ functions:
             - http:
                   path: traces/{device_unique_id}
                   method: get
-                  private: true
+                  private: false
                   cors: true
+            - throttle:
+                  burstLimit: 100
+                  rateLimit: 100
 
 plugins:
     - serverless-webpack


### PR DESCRIPTION
Make get endpoints open to public with throttle enabled on rate and burst limits.  Purpose is for public to be able to crunch the data.

Jira ticket: [MM-16395](https://mattermost.atlassian.net/browse/MM-16395)