### PR TITLE
Filter out device_unique_id  when returning from "/metrics" and re-apply api-key for "/traces"

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -74,11 +74,8 @@ functions:
             - http:
                   path: traces/{device_unique_id}
                   method: get
-                  private: false
+                  private: true
                   cors: true
-            - throttle:
-                  burstLimit: 100
-                  rateLimit: 100
 
 plugins:
     - serverless-webpack

--- a/src/get_metric.js
+++ b/src/get_metric.js
@@ -27,6 +27,10 @@ const getMetric = (event, context, callback) => {
             });
         } else {
             const metric = res.rows[0];
+            if (metric && metric.device_info && metric.device_info.device_unique_id) {
+                delete metric.device_info.device_unique_id;
+            }
+
             response = successResponse({
                 ...metric,
             });

--- a/src/get_metrics.js
+++ b/src/get_metrics.js
@@ -32,8 +32,9 @@ const getMetrics = (event, context, callback) => {
                     err,
                 });
             } else {
+                const metrics = filterMetrics(res.rows);
                 response = successResponse({
-                    metrics: res.rows,
+                    metrics,
                 });
             }
 
@@ -41,5 +42,15 @@ const getMetrics = (event, context, callback) => {
         },
     );
 };
+
+function filterMetrics(metrics = []) {
+    return metrics.map((metric) => {
+        if (metric && metric.device_info && metric.device_info.device_unique_id) {
+            delete metric.device_info.device_unique_id;
+        }
+
+        return metric;
+    });
+}
 
 export default runWarm(getMetrics);


### PR DESCRIPTION
Filter out device_unique_id  when returning from "/metrics" and re-apply api-key for "/traces"
- `/metrics`: filter out device_unique_id when returning data from this public endpoint
- `/metric`: filter out device_unique_id when returning data from this public endpoint
- `/traces`: revert to private since it requires `device_unique_id` to retrieve metrics for particular device